### PR TITLE
Add latest Kanilrós releases and profiles

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -17,8 +17,8 @@ author:
   name: Hrafnkell Brimar
   url: https://kanilros.is/about/
 description: >-
-  Icelandic underground music shaped by electric guitar, mandolins, vocals,
-  and digital instruments.
+  Independently recorded Icelandic underground music shaped by electric guitar,
+  mandolins, vocals, and digital instruments.
 
 baseurl: ""
 url: https://kanilros.is
@@ -27,6 +27,18 @@ url: https://kanilros.is
 twitter_username: kanilros
 instagram_username: kanilros
 facebook_username: kanilros
+
+social:
+  name: Kanilrós
+  links:
+    - https://open.spotify.com/artist/1uXctS0gcqInSzZyKTGLK2
+    - https://youtube.com/@kanilros
+    - https://soundcloud.com/kanilros
+    - https://instagram.com/kanilros
+    - https://x.com/kanilros
+    - https://bsky.app/profile/kanilros.is
+    - https://facebook.com/kanilros
+    - https://music.apple.com/is/artist/kanilr%C3%B3s/1682781331
 
 # ============================================
 # Build Settings

--- a/docs/_data/albums.yml
+++ b/docs/_data/albums.yml
@@ -5,7 +5,7 @@ albums:
     description: >-
       Kanilrós's debut album, an instrumental work mainly centered around the electric guitar.
       Features mandolins, bass, acoustic guitar, and a rich palette of electronic sounds.
-    soundcloud_playlist: "1627981054"
+    spotify_album: "5UM2Y59kE2A4wwLWv8zbZ0"
     
   - id: hive
     title: Hive
@@ -14,9 +14,39 @@ albums:
       Kanilrós's second album and first non-instrumental work. A primarily rock album
       with influences from funk, disco, metal, and folk. Features electric guitar, mandolins,
       acoustic guitars, bass, digital instruments, and vocals.
-    soundcloud_playlist: "1635041593"
+    spotify_album: "5N2sRTJHazcojEf2NkjzNG"
+
+  - id: tape
+    title: Tape
+    release_date: "2023-08-02"
+    description: >-
+      The third Kanilrós album: ten guitar-led rock songs released in the project's
+      prolific first year.
+    spotify_album: "7lMWCOn6b95V59W9x94psQ"
+
+  - id: ghosts
+    title: Ghosts
+    release_date: "2024-10-31"
+    description: >-
+      The nine-song fourth album, featuring Little Birds alongside songs about ghosts,
+      hidden people, vampires, friendship, and the afterlife.
+    spotify_album: "3YE8ZnQUiR7n80siglkDww"
+
+  - id: save-the-world
+    title: Save the World
+    release_date: "2025-09-05"
+    description: >-
+      Kanilrós's fifth and latest album: eleven varied tracks written, performed,
+      recorded, mixed, and produced independently.
+    spotify_album: "0Cq1tMrQWKSxzxwDYKYtJk"
 
 videos:
+  - id: little-birds
+    title: Little Birds
+    release_date: "2024-04-03"
+    description: The official music video for Little Birds, a song later included on Ghosts.
+    youtube_id: "mSeGsM5yXTk"
+
   - id: film-video
     title: Film
     bandcamp_id: "2985362402"

--- a/docs/_data/socials.yml
+++ b/docs/_data/socials.yml
@@ -1,0 +1,16 @@
+- label: Spotify
+  url: https://open.spotify.com/artist/1uXctS0gcqInSzZyKTGLK2
+- label: YouTube
+  url: https://youtube.com/@kanilros
+- label: SoundCloud
+  url: https://soundcloud.com/kanilros
+- label: Instagram
+  url: https://instagram.com/kanilros
+- label: X
+  url: https://x.com/kanilros
+- label: Bluesky
+  url: https://bsky.app/profile/kanilros.is
+- label: Facebook
+  url: https://facebook.com/kanilros
+- label: Apple Music
+  url: https://music.apple.com/is/artist/kanilr%C3%B3s/1682781331

--- a/docs/_includes/spotify-player.html
+++ b/docs/_includes/spotify-player.html
@@ -1,0 +1,9 @@
+<div class="embed embed--spotify">
+  <iframe
+    title="Listen to {{ include.title | escape }} by Kanilrós on Spotify"
+    src="https://open.spotify.com/embed/album/{{ include.album_id }}?utm_source=generator&theme=0"
+    loading="lazy"
+    allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+    referrerpolicy="strict-origin-when-cross-origin">
+  </iframe>
+</div>

--- a/docs/_layouts/albums.html
+++ b/docs/_layouts/albums.html
@@ -12,7 +12,7 @@ layout: page
         <h2>{{ album.title | escape }}</h2>
         <p>{{ album.description | escape }}</p>
       </div>
-      {% include soundcloud-player.html title=album.title playlist_id=album.soundcloud_playlist %}
+      {% include spotify-player.html title=album.title album_id=album.spotify_album %}
     </article>
   {% endfor %}
 </div>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -32,9 +32,9 @@
           <p>Icelandic underground music.</p>
         </div>
         <ul class="social-links" aria-label="Kanilrós elsewhere">
-          <li><a href="https://soundcloud.com/kanilros">SoundCloud</a></li>
-          <li><a href="https://instagram.com/kanilros">Instagram</a></li>
-          <li><a href="https://facebook.com/kanilros">Facebook</a></li>
+          {% for social in site.data.socials %}
+            <li><a href="{{ social.url }}">{{ social.label | escape }}</a></li>
+          {% endfor %}
           <li><a href="mailto:{{ site.email }}">Email</a></li>
         </ul>
       </div>

--- a/docs/_layouts/videos.html
+++ b/docs/_layouts/videos.html
@@ -4,16 +4,39 @@ layout: page
 
 <div class="videos">
   {% for video in site.data.albums.videos %}
-    <article class="video">
-      <h2 class="visually-hidden">{{ video.title | escape }}</h2>
+    <article class="video" id="video-{{ video.id | slugify }}">
+      <div class="video__header">
+        {% if video.release_date %}
+          <p class="release__date">
+            Released <time datetime="{{ video.release_date }}">{{ video.release_date | date: "%e %B %Y" }}</time>
+          </p>
+        {% endif %}
+        <h2>{{ video.title | escape }}</h2>
+        {% if video.description %}<p>{{ video.description | escape }}</p>{% endif %}
+      </div>
       <div class="embed embed--video">
-        <iframe
-          title="Watch {{ video.title | escape }} on Bandcamp"
-          src="https://bandcamp.com/VideoEmbed?track={{ video.bandcamp_id }}&bgcol=171210&linkcol=a94f3f"
-          loading="lazy"
-          allow="fullscreen"
-          referrerpolicy="strict-origin-when-cross-origin">
-        </iframe>
+        {% if video.youtube_id %}
+          <a
+            class="video-link"
+            href="https://www.youtube.com/watch?v={{ video.youtube_id }}"
+            aria-label="Watch {{ video.title | escape }} by Kanilrós on YouTube">
+            <img
+              src="https://i.ytimg.com/vi/{{ video.youtube_id }}/maxresdefault.jpg"
+              alt=""
+              width="1280"
+              height="720"
+              loading="lazy">
+            <span class="video-link__label">Watch on YouTube <span aria-hidden="true">▶</span></span>
+          </a>
+        {% else %}
+          <iframe
+            title="Watch {{ video.title | escape }} on Bandcamp"
+            src="https://bandcamp.com/VideoEmbed?track={{ video.bandcamp_id }}&bgcol=171210&linkcol=a94f3f"
+            loading="lazy"
+            allow="fullscreen"
+            referrerpolicy="strict-origin-when-cross-origin">
+          </iframe>
+        {% endif %}
       </div>
     </article>
   {% endfor %}

--- a/docs/about.markdown
+++ b/docs/about.markdown
@@ -2,12 +2,14 @@
 layout: page
 title: About
 permalink: /about/
-description: Kanilrós means Cinnamon Rose—an Icelandic project built around guitar, strings, electronics, and vocals.
+description: Kanilrós is the independent music project of Icelandic guitarist, songwriter, singer, and producer Hrafnkell Brimar.
 ---
 
 ## About Kanilrós
 
-Kanilrós is the artist name of Hrafnkell Brimar. The name means “Cinnamon Rose,” and the music moves between styles while keeping the electric guitar at its center.
+Kanilrós is the independent music project of Hrafnkell Brimar, a guitarist, songwriter, singer, and multi-instrumentalist from Reykjanesbær, Iceland. The name means “Cinnamon Rose.” Hrafnkell writes, performs, records, mixes, and produces the music himself.
+
+The project began with the instrumental album *Film* in April 2023. *Hive* introduced vocals two months later, followed by *Tape* in August of the same year. The fourth album, *Ghosts*, arrived on Halloween 2024 and includes “Little Birds.” The fifth and latest album, *Save the World*, was released in September 2025.
 
 ### Musical Style
 
@@ -18,5 +20,7 @@ The work encompasses:
 - **Electronic soundscapes** blending digital and acoustic instruments
 - **Vocal tracks** beginning with the second album, *Hive*
 - **Genre influences** ranging from rock and folk to funk, disco, metal, and experimental music
+
+Across five albums, Kanilrós follows the song rather than a fixed genre: the rock and metal guitar background remains audible even when the arrangements turn acoustic, electronic, or orchestral.
 
 Explore the music on the [Listen]({{ '/listen/' | relative_url }}) page and watch videos on the [Watch]({{ '/watch/' | relative_url }}) page.

--- a/docs/assets/main.css
+++ b/docs/assets/main.css
@@ -329,12 +329,75 @@ h3 {
   height: min(28rem, 70vh);
 }
 
+.embed--spotify iframe {
+  height: 22rem;
+}
+
+.video {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.video__header {
+  max-width: 42rem;
+}
+
+.video__header h2 {
+  margin-bottom: 0.75rem;
+}
+
+.video__header > p:last-child:not(.release__date) {
+  color: var(--muted);
+}
+
 .embed--video {
   aspect-ratio: 16 / 9;
 }
 
 .embed--video iframe {
   height: 100%;
+}
+
+.video-link {
+  position: relative;
+  display: block;
+  height: 100%;
+  color: var(--text);
+  background: var(--surface-raised);
+  text-decoration: none;
+}
+
+.video-link::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+  background: linear-gradient(180deg, transparent 45%, rgb(23 18 16 / 82%));
+}
+
+.video-link img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.video-link__label {
+  position: absolute;
+  z-index: 1;
+  bottom: clamp(1rem, 4vw, 2rem);
+  left: clamp(1rem, 4vw, 2rem);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.7rem 1rem;
+  background: var(--accent);
+  border-radius: 999px;
+  font-weight: 750;
+}
+
+.video-link:hover .video-link__label {
+  color: var(--background);
+  background: var(--text);
 }
 
 .site-footer {

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,13 +1,13 @@
 ---
 layout: home
 title: Kanilrós
-description: Icelandic underground music shaped by electric guitar, mandolins, vocals, and digital instruments.
+description: Five albums of independently recorded Icelandic underground rock, from Film to Save the World.
 ---
 
 <section class="hero shell">
   <p class="eyebrow">Icelandic underground music</p>
   <h1>Kanilrós</h1>
-  <p class="hero__intro">Guitar-led music moving between instrumental rock, folk, funk, metal, and electronic sound.</p>
+  <p class="hero__intro">Independently written, performed, recorded, and produced music moving between guitar-led rock, folk, funk, metal, and electronic sound.</p>
   <div class="hero__actions">
     <a class="button" href="{{ '/listen/' | relative_url }}">Listen to the albums</a>
     <a class="text-link" href="{{ '/watch/' | relative_url }}">Watch videos <span aria-hidden="true">→</span></a>
@@ -17,7 +17,7 @@ description: Icelandic underground music shaped by electric guitar, mandolins, v
 <section class="shell home-releases" aria-labelledby="releases-title">
   <div class="section-heading">
     <p class="eyebrow">Discography</p>
-    <h2 id="releases-title">Two records, one restless sound</h2>
+    <h2 id="releases-title">Five records, one restless sound</h2>
   </div>
   <div class="release-grid">
     {% for album in site.data.albums.albums reversed %}

--- a/docs/listen.markdown
+++ b/docs/listen.markdown
@@ -2,5 +2,5 @@
 layout: albums
 title: Listen
 permalink: /listen/
-description: Stream Film and Hive, the first two albums by Kanilrós.
+description: Stream all five Kanilrós albums, from Film and Hive through Tape, Ghosts, and Save the World.
 ---

--- a/docs/watch.markdown
+++ b/docs/watch.markdown
@@ -2,5 +2,5 @@
 layout: videos
 title: Watch
 permalink: /watch/
-description: Watch videos from Kanilrós.
+description: Watch Little Birds and other videos from Kanilrós.
 ---


### PR DESCRIPTION
## Summary
- add Tape, Ghosts, and Save the World with Spotify album players
- add the official Little Birds video poster and YouTube link
- refresh the biography, homepage copy, SEO metadata, and social profiles
- add verified X, Bluesky, Spotify, YouTube, and Apple Music links

## Validation
- production Jekyll build
- HTML-Proofer internal links
- feed and sitemap XML validation
- bundler-audit
- desktop and 390px mobile visual review