### PR TITLE
Redesign Kanilrós site and improve music SEO

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -40,6 +40,10 @@ jobs:
         env:
           JEKYLL_ENV: production
 
+      - name: Validate metadata and structured data
+        working-directory: ./docs
+        run: bundle exec ruby scripts/validate-site.rb
+
       - name: Validate generated HTML
         working-directory: ./docs
         run: bundle exec htmlproofer ./_site --disable-external

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ build:
 	cd docs && JEKYLL_ENV=production bundle exec jekyll build --strict_front_matter
 
 check: build
+	cd docs && bundle exec ruby scripts/validate-site.rb
 	cd docs && bundle exec htmlproofer ./_site --disable-external
 	cd docs && bundle exec bundle-audit check --update
 

--- a/OPTIMIZATION_GUIDE.md
+++ b/OPTIMIZATION_GUIDE.md
@@ -8,8 +8,9 @@ Every run:
 
 1. Installs the Ruby version from `.ruby-version` and the locked gems.
 2. Builds Jekyll with production settings and strict front matter.
-3. Validates generated HTML and internal links with HTMLProofer.
-4. Audits locked gems against the Ruby advisory database.
+3. Validates metadata, image alternatives, and JSON-LD entities.
+4. Validates generated HTML and internal links with HTMLProofer.
+5. Audits locked gems against the Ruby advisory database.
 
 Only a push to `main` uploads and deploys the Pages artifact. The deploy job receives `pages: write` and `id-token: write`; other jobs retain read-only repository access.
 
@@ -24,7 +25,7 @@ Run `make update` to refresh gems manually, then run `make check` before merging
 
 ## Performance
 
-The production site uses generated HTML and one plain CSS file. It has no client-side JavaScript, web-font downloads, theme runtime, or image pipeline. Third-party audio and video players load lazily.
+The production site uses generated HTML and one plain CSS file. It has no client-side JavaScript, web-font downloads, theme runtime, or image pipeline. Canonical album artwork is served by Apple Music's image CDN, while third-party audio and video players load lazily.
 
 GitHub Pages does not support custom response headers. The optional `netlify.toml` contains security and cache headers for a Netlify deployment; equivalent headers require a CDN or proxy when GitHub Pages remains the origin.
 
@@ -33,13 +34,23 @@ GitHub Pages does not support custom response headers. The optional `netlify.tom
 - Add or edit releases in `docs/_data/albums.yml`.
 - Add long-form release pages in `docs/_posts/`.
 - Edit page copy in `docs/*.markdown`.
-- Keep embeds behind the shared `docs/_includes/soundcloud-player.html` include.
+- Keep Spotify embeds behind the shared `docs/_includes/spotify-player.html` include.
+
+## Search and AI discoverability
+
+- `jekyll-seo-tag` generates page titles, descriptions, canonical URLs, and social previews.
+- `docs/_includes/structured-data.html` describes Kanilrós and the five albums with `MusicGroup` and `MusicAlbum` JSON-LD.
+- `docs/robots.txt` allows standard crawlers, OAI-SearchBot, and user-initiated ChatGPT fetches; the sitemap remains the canonical URL inventory.
+- Every album has visible descriptive copy, artwork, release details, streaming links, and a dedicated canonical page.
+- `docs/scripts/validate-site.rb` prevents missing metadata, malformed JSON-LD, and image accessibility regressions in CI.
+
+When adding an album, update `docs/_data/albums.yml` and add a matching post with `layout: release`, `album_id`, a unique description, and social-preview artwork.
 
 ## Local commands
 
 ```bash
 make serve   # development server with live reload
 make build   # strict production build
-make check   # build, HTML validation, dependency audit
+make check   # build, SEO/HTML validation, dependency audit
 make clean   # remove generated Jekyll files
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The source for [kanilros.is](https://kanilros.is), the website of Icelandic unde
 - Ruby 4.0.6 and Bundler
 - GitHub Actions and GitHub Pages
 
-The site lives in `docs/`, matching GitHub Pages conventions. Content is stored in Markdown and `docs/_data/albums.yml`.
+The site lives in `docs/`, matching GitHub Pages conventions. Release metadata and canonical artwork live in `docs/_data/albums.yml`; each album also has an indexable page in `docs/_posts/`.
 
 ## Local development
 
@@ -24,7 +24,7 @@ The development server is available at <http://localhost:4000>.
 
 ## Validation
 
-Run the same build, internal-link validation, and dependency audit used in CI:
+Run the same build, metadata and JSON-LD validation, internal-link validation, and dependency audit used in CI:
 
 ```bash
 make check

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,14 +11,17 @@
 # ============================================
 domain: kanilros.is
 title: Kanilrós
+tagline: Independent Icelandic rock from Reykjanesbær
 email: hrafnkellkanilros@gmail.com
-lang: en
+lang: en-IS
 author:
   name: Hrafnkell Brimar
   url: https://kanilros.is/about/
 description: >-
-  Independently recorded Icelandic underground music shaped by electric guitar,
-  mandolins, vocals, and digital instruments.
+  Kanilrós is the independent music project of Icelandic guitarist, songwriter,
+  singer, multi-instrumentalist, and producer Hrafnkell Brimar.
+image: https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/aa/34/2b/aa342be4-0577-00e8-253b-3abeb62d3d54/artwork.jpg/1000x1000bb.jpg
+logo: /assets/favicon.svg
 
 baseurl: ""
 url: https://kanilros.is
@@ -60,14 +63,14 @@ kramdown:
 # Site Output
 # ============================================
 permalink: /:categories/:title/
-timezone: UTC
+timezone: Atlantic/Reykjavik
 
 # ============================================
 # SEO and Metadata
 # ============================================
 twitter:
   username: kanilros
-  card: summary
+  card: summary_large_image
 
 # ============================================
 # Build Performance

--- a/docs/_data/albums.yml
+++ b/docs/_data/albums.yml
@@ -1,44 +1,79 @@
 albums:
   - id: film
     title: Film
+    permalink: /music/film/
     release_date: "2023-04-15"
+    track_count: 18
+    genre: Rock
+    label: Cinnamon Rose Records
     description: >-
       Kanilrós's debut album, an instrumental work mainly centered around the electric guitar.
       Features mandolins, bass, acoustic guitar, and a rich palette of electronic sounds.
     spotify_album: "5UM2Y59kE2A4wwLWv8zbZ0"
+    spotify_url: https://open.spotify.com/album/5UM2Y59kE2A4wwLWv8zbZ0
+    apple_music_url: https://music.apple.com/is/album/film/1682800877
+    artwork: https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/d1/b4/fe/d1b4fe1a-9398-1135-a926-215cac0db944/artwork.jpg/1000x1000bb.jpg
     
   - id: hive
     title: Hive
+    permalink: /music/hive/
     release_date: "2023-06-14"
+    track_count: 11
+    genre: Rock
+    label: Cinnamon Rose Records
     description: >-
       Kanilrós's second album and first non-instrumental work. A primarily rock album
       with influences from funk, disco, metal, and folk. Features electric guitar, mandolins,
       acoustic guitars, bass, digital instruments, and vocals.
     spotify_album: "5N2sRTJHazcojEf2NkjzNG"
+    spotify_url: https://open.spotify.com/album/5N2sRTJHazcojEf2NkjzNG
+    apple_music_url: https://music.apple.com/is/album/hive/1691775228
+    artwork: https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/f2/f7/08/f2f708dd-2137-71b7-30d8-328bfb1eb5f9/artwork.jpg/1000x1000bb.jpg
 
   - id: tape
     title: Tape
+    permalink: /music/tape/
     release_date: "2023-08-02"
+    track_count: 10
+    genre: Rock
+    label: Cinnamon Rose Records
     description: >-
       The third Kanilrós album: ten guitar-led rock songs released in the project's
       prolific first year.
     spotify_album: "7lMWCOn6b95V59W9x94psQ"
+    spotify_url: https://open.spotify.com/album/7lMWCOn6b95V59W9x94psQ
+    apple_music_url: https://music.apple.com/is/album/tape/1696884237
+    artwork: https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/15/20/4d/15204de1-5fce-8b7e-590a-3d00ace10185/artwork.jpg/1000x1000bb.jpg
 
   - id: ghosts
     title: Ghosts
+    permalink: /music/ghosts/
     release_date: "2024-10-31"
+    track_count: 9
+    genre: Rock
+    label: Cinnamon Rose Records
     description: >-
       The nine-song fourth album, featuring Little Birds alongside songs about ghosts,
       hidden people, vampires, friendship, and the afterlife.
     spotify_album: "3YE8ZnQUiR7n80siglkDww"
+    spotify_url: https://open.spotify.com/album/3YE8ZnQUiR7n80siglkDww
+    apple_music_url: https://music.apple.com/is/album/ghosts/1773641392
+    artwork: https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/02/4c/dd/024cddf0-b0b0-1680-9c05-169bdc675998/artwork.jpg/1000x1000bb.jpg
 
   - id: save-the-world
     title: Save the World
+    permalink: /music/save-the-world/
     release_date: "2025-09-05"
+    track_count: 11
+    genre: Alternative
+    label: Cinnamon Rose Records
     description: >-
       Kanilrós's fifth and latest album: eleven varied tracks written, performed,
       recorded, mixed, and produced independently.
     spotify_album: "0Cq1tMrQWKSxzxwDYKYtJk"
+    spotify_url: https://open.spotify.com/album/0Cq1tMrQWKSxzxwDYKYtJk
+    apple_music_url: https://music.apple.com/is/album/save-the-world/1835834302
+    artwork: https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/aa/34/2b/aa342be4-0577-00e8-253b-3abeb62d3d54/artwork.jpg/1000x1000bb.jpg
 
 videos:
   - id: little-birds

--- a/docs/_includes/navigation.html
+++ b/docs/_includes/navigation.html
@@ -1,10 +1,10 @@
 <nav aria-label="Main navigation">
   <ul class="site-nav">
     <li>
-      <a href="{{ '/listen/' | relative_url }}"{% if page.url == '/listen/' %} aria-current="page"{% endif %}>Listen</a>
+      <a href="{{ '/listen/' | relative_url }}"{% if page.url == '/listen/' or page.album_id %} aria-current="page"{% endif %}>Music</a>
     </li>
     <li>
-      <a href="{{ '/watch/' | relative_url }}"{% if page.url == '/watch/' %} aria-current="page"{% endif %}>Watch</a>
+      <a href="{{ '/watch/' | relative_url }}"{% if page.url == '/watch/' %} aria-current="page"{% endif %}>Videos</a>
     </li>
     <li>
       <a href="{{ '/about/' | relative_url }}"{% if page.url == '/about/' %} aria-current="page"{% endif %}>About</a>

--- a/docs/_includes/structured-data.html
+++ b/docs/_includes/structured-data.html
@@ -1,0 +1,57 @@
+{% assign artist_id = site.url | append: '/#artist' %}
+{% assign current_album = site.data.albums.albums | where: "id", page.album_id | first %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "MusicGroup",
+      "@id": {{ artist_id | jsonify }},
+      "name": "Kanilrós",
+      "url": {{ site.url | append: '/' | jsonify }},
+      "description": {{ site.description | strip_newlines | jsonify }},
+      "image": {{ site.image | jsonify }},
+      "genre": ["Rock", "Alternative", "Folk", "Electronic", "Metal"],
+      "foundingLocation": {
+        "@type": "Place",
+        "name": "Reykjanesbær, Iceland"
+      },
+      "member": {
+        "@type": "Person",
+        "name": "Hrafnkell Brimar",
+        "url": {{ site.author.url | jsonify }}
+      },
+      "sameAs": [{% for link in site.social.links %}{{ link | jsonify }}{% unless forloop.last %},{% endunless %}{% endfor %}],
+      "album": [{% for album in site.data.albums.albums %}{"@id": {{ site.url | append: album.permalink | append: '#album' | jsonify }}}{% unless forloop.last %},{% endunless %}{% endfor %}]
+    }{% if page.url == '/' or page.url == '/listen/' %}{% for album in site.data.albums.albums %},
+    {
+      "@type": "MusicAlbum",
+      "@id": {{ site.url | append: album.permalink | append: '#album' | jsonify }},
+      "name": {{ album.title | jsonify }},
+      "url": {{ site.url | append: album.permalink | jsonify }},
+      "description": {{ album.description | jsonify }},
+      "image": {{ album.artwork | jsonify }},
+      "datePublished": {{ album.release_date | jsonify }},
+      "numTracks": {{ album.track_count }},
+      "genre": {{ album.genre | jsonify }},
+      "byArtist": {"@id": {{ artist_id | jsonify }}},
+      "recordLabel": {"@type": "Organization", "name": {{ album.label | jsonify }}},
+      "sameAs": [{{ album.spotify_url | jsonify }}, {{ album.apple_music_url | jsonify }}]
+    }{% endfor %}{% elsif current_album %},
+    {
+      "@type": "MusicAlbum",
+      "@id": {{ site.url | append: current_album.permalink | append: '#album' | jsonify }},
+      "name": {{ current_album.title | jsonify }},
+      "url": {{ site.url | append: current_album.permalink | jsonify }},
+      "description": {{ current_album.description | jsonify }},
+      "image": {{ current_album.artwork | jsonify }},
+      "datePublished": {{ current_album.release_date | jsonify }},
+      "numTracks": {{ current_album.track_count }},
+      "genre": {{ current_album.genre | jsonify }},
+      "byArtist": {"@id": {{ artist_id | jsonify }}},
+      "recordLabel": {"@type": "Organization", "name": {{ current_album.label | jsonify }}},
+      "sameAs": [{{ current_album.spotify_url | jsonify }}, {{ current_album.apple_music_url | jsonify }}]
+    }{% endif %}
+  ]
+}
+</script>

--- a/docs/_layouts/albums.html
+++ b/docs/_layouts/albums.html
@@ -5,12 +5,25 @@ layout: page
 <div class="albums">
   {% for album in site.data.albums.albums %}
     <article class="release" id="album-{{ album.id | slugify }}">
-      <div class="release__copy">
-        <p class="release__date">
-          Released <time datetime="{{ album.release_date }}">{{ album.release_date | date: "%e %B %Y" }}</time>
-        </p>
-        <h2>{{ album.title | escape }}</h2>
-        <p>{{ album.description | escape }}</p>
+      <div class="release__identity">
+        <a class="release__art" href="{{ album.permalink | relative_url }}" aria-label="Explore {{ album.title | escape }} by Kanilrós">
+          <img src="{{ album.artwork }}" alt="{{ album.title | escape }} album cover" width="1000" height="1000" loading="lazy" decoding="async">
+        </a>
+        <div class="release__copy">
+          <p class="release__date">
+            Released <time datetime="{{ album.release_date }}">{{ album.release_date | date: "%e %B %Y" }}</time>
+          </p>
+          <h2><a href="{{ album.permalink | relative_url }}">{{ album.title | escape }}</a></h2>
+          <p>{{ album.description | escape }}</p>
+          <ul class="release__facts" aria-label="{{ album.title | escape }} album details">
+            <li>{{ album.track_count }} tracks</li>
+            <li>{{ album.genre | escape }}</li>
+          </ul>
+          <div class="release__actions">
+            <a href="{{ album.permalink | relative_url }}">Album details</a>
+            <a href="{{ album.apple_music_url }}">Apple Music <span aria-hidden="true">↗</span></a>
+          </div>
+        </div>
       </div>
       {% include spotify-player.html title=album.title album_id=album.spotify_album %}
     </article>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -3,9 +3,13 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="theme-color" content="#171210">
+    <meta name="theme-color" content="#120d0c">
+    <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
     {% seo %}
+    {% include structured-data.html %}
     <link rel="icon" href="{{ '/assets/favicon.svg' | relative_url }}" type="image/svg+xml">
+    <link rel="preconnect" href="https://is1-ssl.mzstatic.com" crossorigin>
+    {% if page.url == '/listen/' or page.album_id %}<link rel="preconnect" href="https://open.spotify.com">{% endif %}
     <link rel="stylesheet" href="{{ '/assets/main.css' | relative_url }}">
     {% feed_meta %}
   </head>
@@ -15,7 +19,7 @@
     <header class="site-header">
       <div class="shell site-header__inner">
         <a class="site-mark" href="{{ '/' | relative_url }}" aria-label="Kanilrós home">
-          Kanilrós
+          <span aria-hidden="true"></span>Kanilrós
         </a>
         {% include navigation.html %}
       </div>
@@ -29,11 +33,12 @@
       <div class="shell site-footer__inner">
         <div>
           <p class="site-footer__title">Kanilrós</p>
-          <p>Icelandic underground music.</p>
+          <p>Independent music from Reykjanesbær, Iceland.</p>
+          <p class="site-footer__meta">© {{ 'now' | date: '%Y' }} Hrafnkell Brimar.</p>
         </div>
         <ul class="social-links" aria-label="Kanilrós elsewhere">
           {% for social in site.data.socials %}
-            <li><a href="{{ social.url }}">{{ social.label | escape }}</a></li>
+            <li><a href="{{ social.url }}" rel="me">{{ social.label | escape }}</a></li>
           {% endfor %}
           <li><a href="mailto:{{ site.email }}">Email</a></li>
         </ul>

--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -3,13 +3,13 @@ layout: default
 ---
 <article class="shell page">
   <header class="page__header">
-    <p class="eyebrow">Kanilrós</p>
+    <p class="eyebrow">{{ page.eyebrow | default: 'Kanilrós' | escape }}</p>
     <h1>{{ page.title | escape }}</h1>
     {% if page.description %}
       <p class="page__intro">{{ page.description | escape }}</p>
     {% endif %}
   </header>
-  <div class="prose">
+  <div class="{% if page.wide %}page__content page__content--wide{% else %}prose{% endif %}">
     {{ content }}
   </div>
 </article>

--- a/docs/_layouts/release.html
+++ b/docs/_layouts/release.html
@@ -1,0 +1,38 @@
+---
+layout: default
+---
+{% assign album = site.data.albums.albums | where: "id", page.album_id | first %}
+<article class="album-page">
+  <header class="shell album-hero">
+    <div class="album-hero__copy">
+      <a class="back-link" href="{{ '/listen/' | relative_url }}"><span aria-hidden="true">←</span> All music</a>
+      <p class="eyebrow">Kanilrós album · {{ album.release_date | date: "%Y" }}</p>
+      <h1>{{ album.title | escape }}</h1>
+      <p class="album-hero__intro">{{ album.description | escape }}</p>
+      <ul class="release__facts" aria-label="{{ album.title | escape }} album details">
+        <li>{{ album.track_count }} tracks</li>
+        <li>{{ album.genre | escape }}</li>
+        <li>{{ album.release_date | date: "%e %B %Y" }}</li>
+      </ul>
+      <div class="hero__actions">
+        <a class="button" href="{{ album.spotify_url }}">Play on Spotify <span aria-hidden="true">↗</span></a>
+        <a class="text-link" href="{{ album.apple_music_url }}">Apple Music <span aria-hidden="true">↗</span></a>
+      </div>
+    </div>
+    <img class="album-hero__art" src="{{ album.artwork }}" alt="{{ album.title | escape }} album cover" width="1000" height="1000" fetchpriority="high">
+  </header>
+
+  <section class="shell album-player" aria-labelledby="listen-{{ album.id }}">
+    <div class="section-heading">
+      <p class="eyebrow">Listen</p>
+      <h2 id="listen-{{ album.id }}">Play {{ album.title | escape }}</h2>
+    </div>
+    {% include spotify-player.html title=album.title album_id=album.spotify_album %}
+  </section>
+
+  <section class="shell album-notes prose" aria-labelledby="about-{{ album.id }}">
+    <p class="eyebrow">Album notes</p>
+    <h2 id="about-{{ album.id }}">About {{ album.title | escape }}</h2>
+    {{ content }}
+  </section>
+</article>

--- a/docs/_posts/2023-06-14-film.markdown
+++ b/docs/_posts/2023-06-14-film.markdown
@@ -1,11 +1,11 @@
 ---
-layout: post
+layout: release
+album_id: film
 title: Film
-description: The instrumental debut album by Kanilrós.
+description: Film is the 18-track instrumental debut album by Icelandic independent artist Kanilrós.
 date: 2023-04-15 00:00:00 +0000
 categories: music
+image: https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/d1/b4/fe/d1b4fe1a-9398-1135-a926-215cac0db944/artwork.jpg/1000x1000bb.jpg
 ---
 
 *Film* is the instrumental debut by Kanilrós, centered on electric guitar with mandolins, bass, acoustic guitar, and electronic textures.
-
-{% include soundcloud-player.html title="Film" playlist_id="1627981054" %}

--- a/docs/_posts/2023-06-14-hive.markdown
+++ b/docs/_posts/2023-06-14-hive.markdown
@@ -1,11 +1,11 @@
 ---
-layout: post
+layout: release
+album_id: hive
 title: Hive
-description: The second album by Kanilrós, bringing vocals into a rock-focused mix.
+description: Hive is the second album by Kanilrós, bringing vocals into an 11-track rock-focused mix.
 date: 2023-06-14 00:00:00 +0000
 categories: music
+image: https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/f2/f7/08/f2f708dd-2137-71b7-30d8-328bfb1eb5f9/artwork.jpg/1000x1000bb.jpg
 ---
 
 *Hive* is the second Kanilrós album and the first to feature vocals. Its rock foundation crosses into funk, disco, metal, and folk.
-
-{% include soundcloud-player.html title="Hive" playlist_id="1635041593" %}

--- a/docs/_posts/2023-08-02-tape.markdown
+++ b/docs/_posts/2023-08-02-tape.markdown
@@ -1,0 +1,11 @@
+---
+layout: release
+album_id: tape
+title: Tape
+description: Tape is the third Kanilrós album, a 10-track guitar-led rock record released in 2023.
+date: 2023-08-02 00:00:00 +0000
+categories: music
+image: https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/15/20/4d/15204de1-5fce-8b7e-590a-3d00ace10185/artwork.jpg/1000x1000bb.jpg
+---
+
+*Tape* is the third Kanilrós album: ten guitar-led songs released during the project’s prolific first year.

--- a/docs/_posts/2024-10-31-ghosts.markdown
+++ b/docs/_posts/2024-10-31-ghosts.markdown
@@ -1,0 +1,11 @@
+---
+layout: release
+album_id: ghosts
+title: Ghosts
+description: Ghosts is the nine-track fourth album by Kanilrós, featuring Little Birds and Afterlife.
+date: 2024-10-31 00:00:00 +0000
+categories: music
+image: https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/02/4c/dd/024cddf0-b0b0-1680-9c05-169bdc675998/artwork.jpg/1000x1000bb.jpg
+---
+
+Released on Halloween 2024, *Ghosts* brings together songs about hidden people, vampires, friendship, memory, and the afterlife.

--- a/docs/_posts/2025-09-05-save-the-world.markdown
+++ b/docs/_posts/2025-09-05-save-the-world.markdown
@@ -1,0 +1,11 @@
+---
+layout: release
+album_id: save-the-world
+title: Save the World
+description: Save the World is the fifth and latest Kanilrós album, released independently in September 2025.
+date: 2025-09-05 00:00:00 +0000
+categories: music
+image: https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/aa/34/2b/aa342be4-0577-00e8-253b-3abeb62d3d54/artwork.jpg/1000x1000bb.jpg
+---
+
+*Save the World* is an eleven-track album of different shapes and sizes, with every song placed deliberately within the complete record.

--- a/docs/about.markdown
+++ b/docs/about.markdown
@@ -3,13 +3,34 @@ layout: page
 title: About
 permalink: /about/
 description: Kanilrós is the independent music project of Icelandic guitarist, songwriter, singer, and producer Hrafnkell Brimar.
+eyebrow: The artist
+image: https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/aa/34/2b/aa342be4-0577-00e8-253b-3abeb62d3d54/artwork.jpg/1000x1000bb.jpg
 ---
 
-## About Kanilrós
+## The project
 
 Kanilrós is the independent music project of Hrafnkell Brimar, a guitarist, songwriter, singer, and multi-instrumentalist from Reykjanesbær, Iceland. The name means “Cinnamon Rose.” Hrafnkell writes, performs, records, mixes, and produces the music himself.
 
-The project began with the instrumental album *Film* in April 2023. *Hive* introduced vocals two months later, followed by *Tape* in August of the same year. The fourth album, *Ghosts*, arrived on Halloween 2024 and includes “Little Birds.” The fifth and latest album, *Save the World*, was released in September 2025.
+<dl class="artist-facts" markdown="0">
+<div>
+<dt>Based in</dt>
+<dd>Reykjanesbær, Iceland</dd>
+</div>
+<div>
+<dt>Active releases</dt>
+<dd>2023–present</dd>
+</div>
+<div>
+<dt>Albums</dt>
+<dd>Five</dd>
+</div>
+<div>
+<dt>Latest release</dt>
+<dd><a href="{{ '/music/save-the-world/' | relative_url }}">Save the World</a></dd>
+</div>
+</dl>
+
+The project began with the instrumental album *Film* in April 2023. *Hive* introduced vocals two months later, followed by *Tape* in August of the same year. The fourth album, *Ghosts*, arrived on Halloween 2024 and includes “Little Birds.” The fifth and latest album, *Save the World*, was released through Cinnamon Rose Records in September 2025.
 
 ### Musical Style
 

--- a/docs/assets/main.css
+++ b/docs/assets/main.css
@@ -1,18 +1,22 @@
 :root {
   color-scheme: dark;
-  --background: #171210;
-  --surface: #211917;
-  --surface-raised: #2a201d;
-  --text: #f5eee8;
-  --muted: #b9aaa1;
-  --accent: #c36b58;
-  --accent-bright: #e08a74;
-  --border: #493832;
-  --focus: #f3b49f;
-  --shell: 72rem;
-  --reading: 44rem;
-  --radius: 0.75rem;
-  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --background: #120d0c;
+  --surface: #1c1412;
+  --surface-raised: #271b18;
+  --surface-soft: #211714;
+  --text: #fbf3ec;
+  --muted: #c2b2a8;
+  --accent: #db765f;
+  --accent-bright: #f09a82;
+  --border: #49352f;
+  --border-bright: #684b42;
+  --focus: #ffc1ad;
+  --shell: 76rem;
+  --reading: 46rem;
+  --radius: 1rem;
+  --shadow: 0 1.5rem 4rem rgb(0 0 0 / 38%);
+  --display: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, "Times New Roman", serif;
+  font-family: "Avenir Next", Avenir, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-synthesis: none;
 }
 
@@ -32,10 +36,16 @@ body {
   margin: 0;
   color: var(--text);
   background:
-    radial-gradient(circle at 85% 5%, rgb(126 62 49 / 22%), transparent 28rem),
-    var(--background);
+    radial-gradient(circle at 90% 4%, rgb(165 73 55 / 22%), transparent 27rem),
+    radial-gradient(circle at 12% 36%, rgb(91 49 89 / 12%), transparent 34rem),
+    linear-gradient(180deg, #150f0e 0%, var(--background) 35rem);
   font-size: 1rem;
   line-height: 1.65;
+}
+
+::selection {
+  color: var(--background);
+  background: var(--accent-bright);
 }
 
 a {
@@ -59,6 +69,10 @@ iframe {
   max-width: 100%;
 }
 
+img {
+  height: auto;
+}
+
 h1,
 h2,
 h3,
@@ -69,22 +83,24 @@ p {
 h1,
 h2,
 h3 {
-  line-height: 1.08;
+  line-height: 1.02;
   text-wrap: balance;
 }
 
-h1 {
-  font-family: Georgia, "Times New Roman", serif;
-  font-size: clamp(3rem, 10vw, 7.5rem);
+h1,
+h2 {
+  font-family: var(--display);
   font-weight: 400;
-  letter-spacing: -0.055em;
+}
+
+h1 {
+  font-size: clamp(3.5rem, 10vw, 8.5rem);
+  letter-spacing: -0.065em;
 }
 
 h2 {
-  font-family: Georgia, "Times New Roman", serif;
-  font-size: clamp(2rem, 5vw, 3.5rem);
-  font-weight: 400;
-  letter-spacing: -0.035em;
+  font-size: clamp(2.2rem, 5vw, 4.25rem);
+  letter-spacing: -0.045em;
 }
 
 h3 {
@@ -98,13 +114,13 @@ h3 {
 
 .skip-link {
   position: fixed;
-  z-index: 10;
+  z-index: 100;
   top: 0.75rem;
   left: 0.75rem;
   padding: 0.65rem 0.9rem;
   color: var(--background);
   background: var(--text);
-  border-radius: 0.35rem;
+  border-radius: 0.4rem;
   transform: translateY(-180%);
 }
 
@@ -113,7 +129,12 @@ h3 {
 }
 
 .site-header {
-  border-bottom: 1px solid var(--border);
+  position: sticky;
+  z-index: 20;
+  top: 0;
+  background: rgb(18 13 12 / 88%);
+  border-bottom: 1px solid rgb(73 53 47 / 72%);
+  backdrop-filter: blur(1rem);
 }
 
 .site-header__inner {
@@ -121,35 +142,55 @@ h3 {
   align-items: center;
   justify-content: space-between;
   gap: 1.5rem;
-  min-height: 5rem;
+  min-height: 4.75rem;
 }
 
 .site-mark {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
   color: var(--text);
-  font-family: Georgia, "Times New Roman", serif;
-  font-size: 1.45rem;
+  font-family: var(--display);
+  font-size: 1.4rem;
+  font-weight: 700;
   text-decoration: none;
+}
+
+.site-mark span {
+  width: 0.85rem;
+  aspect-ratio: 1;
+  background: var(--accent);
+  border: 0.2rem solid var(--text);
+  border-radius: 50%;
+  box-shadow: 0 0 0 0.15rem var(--accent);
 }
 
 .site-nav,
 .social-links {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem 1.25rem;
+  gap: 0.5rem;
   padding: 0;
   margin: 0;
   list-style: none;
 }
 
 .site-nav a {
+  display: block;
+  padding: 0.45rem 0.75rem;
   color: var(--muted);
-  font-size: 0.92rem;
-  font-weight: 650;
-  letter-spacing: 0.035em;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.025em;
   text-decoration: none;
 }
 
-.site-nav a[aria-current="page"],
+.site-nav a[aria-current="page"] {
+  color: var(--text);
+  background: var(--surface-raised);
+}
+
 .site-nav a:hover {
   color: var(--text);
 }
@@ -160,42 +201,53 @@ h3 {
 
 .hero {
   display: grid;
-  align-content: center;
-  min-height: min(43rem, calc(100vh - 5rem));
-  padding-block: clamp(5rem, 13vw, 9rem);
+  grid-template-columns: minmax(0, 1.08fr) minmax(19rem, 0.72fr);
+  align-items: center;
+  gap: clamp(3rem, 8vw, 7rem);
+  min-height: min(48rem, calc(100vh - 4.75rem));
+  padding-block: clamp(5rem, 10vw, 8rem);
+}
+
+.hero__copy {
+  position: relative;
+  z-index: 1;
 }
 
 .hero h1 {
-  max-width: 9ch;
-  margin-bottom: 1.25rem;
+  max-width: 8ch;
+  margin-bottom: 1.4rem;
 }
 
 .hero__intro {
-  max-width: 38rem;
+  max-width: 41rem;
   margin-bottom: 2rem;
   color: var(--muted);
-  font-size: clamp(1.15rem, 2vw, 1.4rem);
+  font-size: clamp(1.1rem, 2vw, 1.42rem);
+  line-height: 1.6;
 }
 
-.hero__actions {
+.hero__actions,
+.release__actions {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 1rem 1.5rem;
+  gap: 0.85rem 1.35rem;
 }
 
 .button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 3rem;
-  padding: 0.65rem 1rem;
+  gap: 0.65rem;
+  min-height: 3.15rem;
+  padding: 0.7rem 1.15rem;
   color: var(--text);
   background: var(--accent);
   border: 1px solid var(--accent);
   border-radius: 999px;
-  font-weight: 700;
+  font-weight: 750;
   text-decoration: none;
+  box-shadow: 0 0.7rem 1.8rem rgb(219 118 95 / 16%);
 }
 
 .button:hover {
@@ -204,17 +256,113 @@ h3 {
   border-color: var(--text);
 }
 
-.text-link {
-  font-weight: 700;
+.text-link,
+.back-link {
+  font-weight: 750;
+}
+
+.hero__facts,
+.release__facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem 1.35rem;
+  padding: 0;
+  margin: 2rem 0 0;
+  color: var(--muted);
+  font-size: 0.88rem;
+  list-style: none;
+}
+
+.hero__facts li,
+.release__facts li {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.hero__facts li:not(:first-child)::before,
+.release__facts li:not(:first-child)::before {
+  width: 0.28rem;
+  aspect-ratio: 1;
+  content: "";
+  background: var(--accent);
+  border-radius: 50%;
+}
+
+.hero-release {
+  position: relative;
+  display: block;
+  width: min(100%, 30rem);
+  margin-left: auto;
+  padding: 1.5rem 0 1rem;
+  color: var(--text);
+  text-decoration: none;
+}
+
+.hero-release::before {
+  position: absolute;
+  z-index: 0;
+  top: 9%;
+  right: -2%;
+  width: 74%;
+  aspect-ratio: 1;
+  content: "";
+  background:
+    radial-gradient(circle, var(--background) 0 7%, transparent 7.5%),
+    repeating-radial-gradient(circle, #1d1817 0 0.28rem, #342824 0.3rem 0.38rem);
+  border: 1px solid var(--border-bright);
+  border-radius: 50%;
+  box-shadow: var(--shadow);
+}
+
+.hero-release > img {
+  position: relative;
+  z-index: 1;
+  display: block;
+  width: 86%;
+  aspect-ratio: 1;
+  object-fit: cover;
+  border: 1px solid var(--border-bright);
+  border-radius: 0.35rem;
+  box-shadow: var(--shadow);
+  transform: rotate(-2deg);
+  transition: transform 180ms ease;
+}
+
+.hero-release:hover > img {
+  transform: rotate(0deg) translateY(-0.3rem);
+}
+
+.hero-release__meta {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  width: 84%;
+  gap: 0.12rem;
+  padding: 1rem 1.15rem;
+  margin: -2.9rem 0 0 auto;
+  color: var(--muted);
+  background: rgb(39 27 24 / 94%);
+  border: 1px solid var(--border-bright);
+  border-radius: 0.75rem;
+  box-shadow: 0 1rem 2.4rem rgb(0 0 0 / 32%);
+  font-size: 0.82rem;
+  backdrop-filter: blur(0.8rem);
+}
+
+.hero-release__meta strong {
+  color: var(--text);
+  font-family: var(--display);
+  font-size: 1.45rem;
 }
 
 .eyebrow,
 .release__date,
 .page__meta,
-.release-card > p:first-child {
+.release-card__body > p:first-child {
   color: var(--accent-bright);
-  font-size: 0.76rem;
-  font-weight: 750;
+  font-size: 0.74rem;
+  font-weight: 800;
   letter-spacing: 0.16em;
   text-transform: uppercase;
 }
@@ -222,59 +370,118 @@ h3 {
 .home-releases,
 .page,
 .error-page {
-  padding-block: clamp(4rem, 9vw, 7rem);
+  padding-block: clamp(4.5rem, 9vw, 8rem);
+}
+
+.home-releases {
+  border-top: 1px solid var(--border);
 }
 
 .section-heading {
-  max-width: 46rem;
-  margin-bottom: 2rem;
+  max-width: 52rem;
+  margin-bottom: clamp(2rem, 5vw, 3.5rem);
+}
+
+.section-heading h2 {
+  margin-bottom: 1rem;
+}
+
+.section-heading > p:last-child {
+  color: var(--muted);
+  font-size: 1.1rem;
 }
 
 .release-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.2rem;
 }
 
 .release-card {
   display: flex;
+  overflow: hidden;
   flex-direction: column;
-  min-height: 20rem;
-  padding: clamp(1.5rem, 4vw, 2.5rem);
+  min-width: 0;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
+  transition: transform 180ms ease, border-color 180ms ease;
+}
+
+.release-card:hover {
+  border-color: var(--border-bright);
+  transform: translateY(-0.3rem);
+}
+
+.release-card__art {
+  display: block;
+  overflow: hidden;
+  aspect-ratio: 1;
+  background: var(--surface-raised);
+}
+
+.release-card__art img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 240ms ease;
+}
+
+.release-card:hover .release-card__art img {
+  transform: scale(1.025);
+}
+
+.release-card__body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 17rem;
+  padding: 1.4rem;
 }
 
 .release-card h3 {
-  margin-bottom: 1rem;
-  font-family: Georgia, "Times New Roman", serif;
+  margin-bottom: 0.8rem;
+  font-family: var(--display);
   font-size: 2rem;
   font-weight: 400;
 }
 
-.release-card > p:not(:first-child) {
-  color: var(--muted);
+.release-card h3 a {
+  color: var(--text);
+  text-decoration: none;
 }
 
-.release-card a {
+.release-card__body > p:not(:first-child) {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--muted);
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+}
+
+.release-card__link {
   margin-top: auto;
-  font-weight: 700;
+  font-weight: 750;
 }
 
 .page__header {
-  max-width: 55rem;
-  margin-bottom: clamp(3rem, 8vw, 6rem);
+  max-width: 63rem;
+  margin-bottom: clamp(3.5rem, 8vw, 6.5rem);
 }
 
 .page__header h1 {
-  margin-bottom: 1.25rem;
+  margin-bottom: 1.3rem;
 }
 
 .page__intro {
-  max-width: 38rem;
+  max-width: 44rem;
   color: var(--muted);
-  font-size: 1.2rem;
+  font-size: clamp(1.1rem, 2vw, 1.32rem);
+}
+
+.page__content--wide {
+  width: 100%;
 }
 
 .prose {
@@ -282,34 +489,110 @@ h3 {
 }
 
 .prose > * + * {
-  margin-top: 1.25rem;
+  margin-top: 1.35rem;
+}
+
+.prose h2 {
+  margin-top: 3rem;
 }
 
 .prose li + li {
   margin-top: 0.5rem;
 }
 
+.artist-facts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  padding: 0;
+  margin-block: 2rem;
+}
+
+.artist-facts div {
+  padding: 1.2rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+}
+
+.artist-facts dt {
+  color: var(--accent-bright);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.artist-facts dd {
+  margin: 0.25rem 0 0;
+  color: var(--text);
+  font-weight: 700;
+}
+
 .albums,
 .videos {
   display: grid;
-  gap: clamp(3rem, 8vw, 6rem);
+  gap: clamp(3.5rem, 8vw, 7rem);
 }
 
 .release {
   display: grid;
-  grid-template-columns: minmax(0, 0.75fr) minmax(20rem, 1.25fr);
-  gap: clamp(2rem, 6vw, 5rem);
-  align-items: start;
-  padding-top: clamp(2rem, 5vw, 4rem);
+  grid-template-columns: minmax(0, 1.25fr) minmax(20rem, 0.75fr);
+  gap: clamp(1.5rem, 4vw, 3rem);
+  align-items: stretch;
+  padding-top: clamp(2.5rem, 6vw, 5rem);
   border-top: 1px solid var(--border);
+  scroll-margin-top: 6rem;
+}
+
+.release__identity {
+  display: grid;
+  grid-template-columns: minmax(10rem, 13rem) minmax(0, 1fr);
+  gap: clamp(1.3rem, 3vw, 2.2rem);
+  align-items: start;
+  padding: 1.25rem;
+  background: linear-gradient(135deg, var(--surface), var(--surface-soft));
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.release__art {
+  display: block;
+  overflow: hidden;
+  aspect-ratio: 1;
+  border-radius: 0.55rem;
+  box-shadow: 0 0.8rem 2rem rgb(0 0 0 / 28%);
+}
+
+.release__art img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .release__copy h2 {
-  margin-bottom: 1rem;
+  margin-bottom: 0.8rem;
+  font-size: clamp(2.2rem, 4vw, 3.5rem);
 }
 
-.release__copy > p:last-child {
+.release__copy h2 a {
+  color: var(--text);
+  text-decoration: none;
+}
+
+.release__copy > p:not(.release__date) {
   color: var(--muted);
+}
+
+.release__copy .release__facts {
+  margin-top: 1.2rem;
+}
+
+.release__actions {
+  margin-top: 1.3rem;
+  font-size: 0.9rem;
+  font-weight: 750;
 }
 
 .embed {
@@ -335,11 +618,16 @@ h3 {
 
 .video {
   display: grid;
-  gap: 1.5rem;
+  grid-template-columns: minmax(13rem, 0.55fr) minmax(20rem, 1.45fr);
+  gap: clamp(1.5rem, 5vw, 4rem);
+  align-items: start;
+  padding-top: clamp(2.5rem, 6vw, 5rem);
+  border-top: 1px solid var(--border);
 }
 
 .video__header {
-  max-width: 42rem;
+  position: sticky;
+  top: 7rem;
 }
 
 .video__header h2 {
@@ -371,7 +659,7 @@ h3 {
   position: absolute;
   inset: 0;
   content: "";
-  background: linear-gradient(180deg, transparent 45%, rgb(23 18 16 / 82%));
+  background: linear-gradient(180deg, transparent 45%, rgb(18 13 12 / 86%));
 }
 
 .video-link img {
@@ -400,18 +688,71 @@ h3 {
   background: var(--text);
 }
 
+.album-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(20rem, 0.72fr);
+  align-items: center;
+  gap: clamp(3rem, 9vw, 8rem);
+  min-height: min(47rem, calc(100vh - 4.75rem));
+  padding-block: clamp(4rem, 9vw, 7rem);
+}
+
+.album-hero h1 {
+  margin-block: 1.4rem;
+}
+
+.album-hero__intro {
+  max-width: 40rem;
+  color: var(--muted);
+  font-size: clamp(1.1rem, 2vw, 1.32rem);
+}
+
+.album-hero__art {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1;
+  object-fit: cover;
+  border: 1px solid var(--border-bright);
+  border-radius: 0.5rem;
+  box-shadow: var(--shadow);
+  transform: rotate(1.5deg);
+}
+
+.back-link {
+  display: inline-flex;
+  gap: 0.55rem;
+  margin-bottom: 2.5rem;
+  text-decoration: none;
+}
+
+.album-player,
+.album-notes {
+  padding-block: clamp(4rem, 8vw, 7rem);
+  border-top: 1px solid var(--border);
+}
+
+.album-player .embed {
+  max-width: 54rem;
+}
+
+.album-notes h2 {
+  margin-bottom: 1.5rem;
+}
+
 .site-footer {
-  margin-top: clamp(3rem, 8vw, 7rem);
+  margin-top: clamp(4rem, 9vw, 8rem);
+  background: rgb(28 20 18 / 58%);
   border-top: 1px solid var(--border);
 }
 
 .site-footer__inner {
-  display: flex;
-  justify-content: space-between;
-  gap: 2rem;
-  padding-block: 2.5rem;
+  display: grid;
+  grid-template-columns: minmax(15rem, 0.7fr) minmax(20rem, 1.3fr);
+  gap: 2.5rem;
+  align-items: start;
+  padding-block: 3.5rem;
   color: var(--muted);
-  font-size: 0.92rem;
+  font-size: 0.9rem;
 }
 
 .site-footer__inner p {
@@ -420,15 +761,33 @@ h3 {
 
 .site-footer__title {
   color: var(--text);
-  font-weight: 750;
+  font-family: var(--display);
+  font-size: 1.35rem;
+  font-weight: 700;
+}
+
+.site-footer__meta {
+  margin-top: 0.8rem;
+  font-size: 0.78rem;
 }
 
 .social-links {
   justify-content: flex-end;
+  gap: 0.6rem;
 }
 
 .social-links a {
+  display: block;
+  padding: 0.4rem 0.7rem;
   color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  text-decoration: none;
+}
+
+.social-links a:hover {
+  color: var(--text);
+  border-color: var(--border-bright);
 }
 
 .error-page {
@@ -458,24 +817,65 @@ h3 {
   border: 0;
 }
 
-@media (max-width: 45rem) {
-  .site-header__inner,
-  .site-footer__inner {
-    align-items: flex-start;
-    flex-direction: column;
+@media (max-width: 64rem) {
+  .release-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .site-header__inner {
-    padding-block: 1rem;
-  }
-
-  .release-grid,
   .release {
     grid-template-columns: 1fr;
   }
 
-  .release-card {
-    min-height: 17rem;
+  .release__identity {
+    grid-template-columns: minmax(10rem, 14rem) minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 48rem) {
+  .site-header__inner,
+  .site-footer__inner {
+    align-items: flex-start;
+  }
+
+  .site-header__inner {
+    min-height: auto;
+    padding-block: 0.9rem;
+  }
+
+  .site-header {
+    position: static;
+  }
+
+  .hero,
+  .album-hero {
+    grid-template-columns: 1fr;
+    min-height: 0;
+  }
+
+  .hero {
+    gap: 2.5rem;
+  }
+
+  .hero-release {
+    width: min(88%, 25rem);
+    margin-inline: auto;
+  }
+
+  .album-hero__art {
+    width: min(88%, 30rem);
+    margin-inline: auto;
+  }
+
+  .video {
+    grid-template-columns: 1fr;
+  }
+
+  .video__header {
+    position: static;
+  }
+
+  .site-footer__inner {
+    grid-template-columns: 1fr;
   }
 
   .social-links {
@@ -483,8 +883,59 @@ h3 {
   }
 }
 
+@media (max-width: 38rem) {
+  .site-header__inner {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .site-nav a {
+    padding-left: 0;
+    padding-right: 1rem;
+    background: none !important;
+  }
+
+  .hero__facts,
+  .release__facts {
+    display: grid;
+    gap: 0.35rem;
+  }
+
+  .hero__facts li:not(:first-child)::before,
+  .release__facts li:not(:first-child)::before {
+    display: none;
+  }
+
+  .release-grid,
+  .release__identity,
+  .artist-facts {
+    grid-template-columns: 1fr;
+  }
+
+  .release-card__body {
+    min-height: 15rem;
+  }
+
+  .release__art {
+    width: min(70%, 16rem);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+  }
+}
+
+@media (prefers-contrast: more) {
+  :root {
+    --muted: #e2d5ce;
+    --border: #8a695f;
   }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,30 +2,53 @@
 layout: home
 title: Kanilrós
 description: Five albums of independently recorded Icelandic underground rock, from Film to Save the World.
+image: https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/aa/34/2b/aa342be4-0577-00e8-253b-3abeb62d3d54/artwork.jpg/1000x1000bb.jpg
 ---
 
-<section class="hero shell">
-  <p class="eyebrow">Icelandic underground music</p>
-  <h1>Kanilrós</h1>
-  <p class="hero__intro">Independently written, performed, recorded, and produced music moving between guitar-led rock, folk, funk, metal, and electronic sound.</p>
-  <div class="hero__actions">
-    <a class="button" href="{{ '/listen/' | relative_url }}">Listen to the albums</a>
-    <a class="text-link" href="{{ '/watch/' | relative_url }}">Watch videos <span aria-hidden="true">→</span></a>
+{% assign latest_album = site.data.albums.albums | last %}
+<section class="hero shell" aria-labelledby="hero-title">
+  <div class="hero__copy">
+    <p class="eyebrow">Independent music · Reykjanesbær, Iceland</p>
+    <h1 id="hero-title">Kanilrós</h1>
+    <p class="hero__intro">Guitar-led songs that move freely through rock, folk, funk, metal, and electronic sound—written, performed, recorded, and produced independently.</p>
+    <div class="hero__actions">
+      <a class="button" href="{{ latest_album.spotify_url }}">Play the latest album <span aria-hidden="true">↗</span></a>
+      <a class="text-link" href="{{ '/listen/' | relative_url }}">Explore all music <span aria-hidden="true">→</span></a>
+    </div>
+    <ul class="hero__facts" aria-label="Kanilrós at a glance">
+      <li>Five albums</li>
+      <li>2023–2025</li>
+      <li>Cinnamon Rose Records</li>
+    </ul>
   </div>
+  <a class="hero-release" href="{{ latest_album.permalink | relative_url }}" aria-label="Explore {{ latest_album.title | escape }}, the latest album by Kanilrós">
+    <img src="{{ latest_album.artwork }}" alt="{{ latest_album.title | escape }} album cover" width="1000" height="1000" fetchpriority="high">
+    <span class="hero-release__meta">
+      <span>Latest album · {{ latest_album.release_date | date: "%Y" }}</span>
+      <strong>{{ latest_album.title | escape }}</strong>
+      <span>{{ latest_album.track_count }} tracks · {{ latest_album.genre | escape }}</span>
+    </span>
+  </a>
 </section>
 
 <section class="shell home-releases" aria-labelledby="releases-title">
   <div class="section-heading">
     <p class="eyebrow">Discography</p>
-    <h2 id="releases-title">Five records, one restless sound</h2>
+    <h2 id="releases-title">Five records, no fixed genre</h2>
+    <p>From the instrumental debut <em>Film</em> to the expansive <em>Save the World</em>.</p>
   </div>
   <div class="release-grid">
     {% for album in site.data.albums.albums reversed %}
       <article class="release-card">
-        <p><time datetime="{{ album.release_date }}">{{ album.release_date | date: "%Y" }}</time></p>
-        <h3>{{ album.title | escape }}</h3>
-        <p>{{ album.description | escape }}</p>
-        <a href="{{ '/listen/' | append: '#album-' | append: album.id | relative_url }}">Listen to {{ album.title | escape }}</a>
+        <a class="release-card__art" href="{{ album.permalink | relative_url }}" aria-label="Explore {{ album.title | escape }} by Kanilrós">
+          <img src="{{ album.artwork }}" alt="{{ album.title | escape }} album cover" width="1000" height="1000" loading="lazy" decoding="async">
+        </a>
+        <div class="release-card__body">
+          <p><time datetime="{{ album.release_date }}">{{ album.release_date | date: "%Y" }}</time> · {{ album.track_count }} tracks</p>
+          <h3><a href="{{ album.permalink | relative_url }}">{{ album.title | escape }}</a></h3>
+          <p>{{ album.description | escape }}</p>
+          <a class="release-card__link" href="{{ '/listen/' | append: '#album-' | append: album.id | relative_url }}">Listen <span aria-hidden="true">→</span></a>
+        </div>
       </article>
     {% endfor %}
   </div>

--- a/docs/listen.markdown
+++ b/docs/listen.markdown
@@ -1,6 +1,9 @@
 ---
 layout: albums
-title: Listen
+title: Music & albums
 permalink: /listen/
-description: Stream all five Kanilrós albums, from Film and Hive through Tape, Ghosts, and Save the World.
+eyebrow: Discography
+wide: true
+description: Explore and stream all five Kanilrós albums, from the instrumental debut Film to the latest release Save the World.
+image: https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/aa/34/2b/aa342be4-0577-00e8-253b-3abeb62d3d54/artwork.jpg/1000x1000bb.jpg
 ---

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,10 @@
+User-agent: *
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+Sitemap: https://kanilros.is/sitemap.xml

--- a/docs/scripts/validate-site.rb
+++ b/docs/scripts/validate-site.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "json"
+require "nokogiri"
+
+site_root = ARGV.fetch(0, "_site")
+errors = []
+structured_nodes = []
+
+Dir.glob(File.join(site_root, "**", "*.html")).sort.each do |file|
+  document = Nokogiri::HTML(File.read(file))
+  relative_path = file.delete_prefix("#{site_root}/")
+
+  errors << "#{relative_path}: expected one h1" unless document.css("h1").length == 1
+  errors << "#{relative_path}: missing title" if document.at_css("title")&.text.to_s.strip.empty?
+  errors << "#{relative_path}: missing description" unless document.at_css('meta[name="description"]')
+  errors << "#{relative_path}: missing canonical URL" unless document.at_css('link[rel="canonical"]')
+  errors << "#{relative_path}: missing robots preview directives" unless document.at_css('meta[name="robots"]')
+
+  document.css("img").each do |image|
+    errors << "#{relative_path}: image missing alt attribute" unless image.key?("alt")
+  end
+
+  document.css('script[type="application/ld+json"]').each do |script|
+    parsed = JSON.parse(script.text)
+    structured_nodes.concat(parsed.fetch("@graph", [parsed]))
+  rescue JSON::ParserError => error
+    errors << "#{relative_path}: invalid JSON-LD (#{error.message})"
+  end
+end
+
+music_group = structured_nodes.find { |node| node["@type"] == "MusicGroup" }
+album_ids = structured_nodes
+  .select { |node| node["@type"] == "MusicAlbum" }
+  .map { |node| node["@id"] }
+  .uniq
+
+errors << "missing MusicGroup structured data" unless music_group
+errors << "expected five unique MusicAlbum entities" unless album_ids.length == 5
+
+abort(errors.join("\n")) unless errors.empty?
+
+html_count = Dir.glob(File.join(site_root, "**", "*.html")).length
+puts "Validated #{html_count} HTML files and #{album_ids.length} albums"

--- a/docs/watch.markdown
+++ b/docs/watch.markdown
@@ -1,6 +1,9 @@
 ---
 layout: videos
-title: Watch
+title: Music videos
 permalink: /watch/
-description: Watch Little Birds and other videos from Kanilrós.
+eyebrow: Watch
+wide: true
+description: Watch the official Little Birds music video and other visual releases from Icelandic artist Kanilrós.
+image: https://i.ytimg.com/vi/mSeGsM5yXTk/maxresdefault.jpg
 ---


### PR DESCRIPTION
## Summary
- redesign the homepage, music catalog, artist page, navigation, and footer around canonical album artwork
- add dedicated responsive pages for all five albums with Spotify and Apple Music links
- add MusicGroup and MusicAlbum JSON-LD, canonical metadata, large social previews, and crawler preview directives
- allow OAI-SearchBot and user-initiated ChatGPT fetches in robots.txt
- add CI validation for metadata, image alternatives, and JSON-LD entities

## Validation
- strict production Jekyll build
- 10-page metadata and JSON-LD validation
- HTML-Proofer internal links and anchors
- feed and sitemap XML validation
- bundler-audit
- desktop and 390px mobile visual review with no console errors