### PR TITLE
Pin GitHub Actions to verified commits

### DIFF
--- a/.github/scripts/check-action-pins-test.rb
+++ b/.github/scripts/check-action-pins-test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "open3"
+require "rbconfig"
+require "tmpdir"
+
+CHECKER = File.expand_path("check-action-pins.rb", __dir__)
+FULL_SHA = "a" * 40
+IMAGE_DIGEST = "b" * 64
+
+def check(content)
+  Dir.mktmpdir("action-pin-test") do |directory|
+    workflow = File.join(directory, "workflow.yml")
+    File.write(workflow, content)
+    Open3.capture3(RbConfig.ruby, CHECKER, workflow)
+  end
+end
+
+def assert(condition, message)
+  raise message unless condition
+end
+
+stdout, stderr, status = check(<<~YAML)
+  jobs:
+    build:
+      steps:
+        - uses: actions/checkout@v7
+        - uses: ruby/setup-ruby@v1
+YAML
+assert(!status.success?, "mutable tags must fail")
+assert(stderr.include?("actions/checkout@v7"), "checkout violation must be reported")
+assert(stderr.include?("ruby/setup-ruby@v1"), "Ruby setup violation must be reported")
+assert(stdout.empty?, "failed checks must not print a success summary")
+
+stdout, stderr, status = check(<<~YAML)
+  jobs:
+    build:
+      steps:
+        - uses: actions/checkout@#{FULL_SHA} # v7
+        - uses: owner/repository/path/to/action@#{FULL_SHA}
+        - uses: ./local-action
+        - uses: docker://example/image@sha256:#{IMAGE_DIGEST}
+YAML
+assert(status.success?, "immutable and local references must pass")
+assert(stderr.empty?, "passing checks must not print errors")
+assert(stdout.include?("Validated 4 immutable action references"), "success summary must count references")
+
+_stdout, stderr, status = check(<<~'YAML')
+  jobs:
+    build:
+      steps:
+        - uses: actions/checkout@deadbeef
+        - uses: actions/checkout@main
+        - uses: ${{ matrix.action }}
+        - uses: docker://example/image:latest
+        - { "uses": actions/checkout@v7 }
+        - uses : actions/configure-pages@v6
+YAML
+assert(!status.success?, "short SHAs, branches, expressions, and Docker tags must fail")
+assert(stderr.lines.length == 6, "every invalid YAML form must be reported")
+
+puts "Validated action pin policy regressions"

--- a/.github/scripts/check-action-pins.rb
+++ b/.github/scripts/check-action-pins.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+SHA40 = "[0-9a-fA-F]{40}"
+SHA256 = "[0-9a-fA-F]{64}"
+GITHUB_REFERENCE = /\A[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\/[A-Za-z0-9_.\/-]+)?@#{SHA40}\z/
+DOCKER_REFERENCE = /\Adocker:\/\/[^@\s]+@sha256:#{SHA256}\z/
+
+def workflow_files(paths)
+  paths.flat_map do |path|
+    if File.directory?(path)
+      Dir.glob(File.join(path, "**", "*.{yml,yaml}"))
+    elsif File.file?(path)
+      path
+    else
+      []
+    end
+  end.uniq.sort
+end
+
+def action_references(value, path = [], references = [])
+  case value
+  when Hash
+    value.each do |key, child|
+      child_path = path + [key.to_s]
+      references << [child_path, child] if key.to_s == "uses"
+      action_references(child, child_path, references)
+    end
+  when Array
+    value.each_with_index do |child, index|
+      action_references(child, path + [index.to_s], references)
+    end
+  end
+
+  references
+end
+
+def pinned_reference?(reference)
+  return false unless reference.is_a?(String)
+  return true if reference.start_with?("./")
+  return DOCKER_REFERENCE.match?(reference) if reference.start_with?("docker://")
+
+  GITHUB_REFERENCE.match?(reference)
+end
+
+paths = ARGV.empty? ? [".github/workflows"] : ARGV
+files = workflow_files(paths)
+
+if files.empty?
+  warn "No workflow files found in: #{paths.join(', ')}"
+  exit 2
+end
+
+violations = []
+reference_count = 0
+
+files.each do |file|
+  workflow = YAML.safe_load(File.read(file), aliases: true)
+  action_references(workflow).each do |path, reference|
+    reference_count += 1
+    next if pinned_reference?(reference)
+
+    violations << "#{file}:#{path.join('.')}: #{reference.inspect} must use a full commit SHA"
+  end
+rescue Psych::SyntaxError => error
+  violations << "#{file}: invalid YAML (#{error.message.lines.first.strip})"
+end
+
+unless violations.empty?
+  warn violations.join("\n")
+  exit 1
+end
+
+puts "Validated #{reference_count} immutable action references across #{files.length} workflow files"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -25,14 +25,19 @@ jobs:
       pages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1
         with:
           ruby-version: "4.0.6"
           bundler-cache: true
           working-directory: ./docs
+
+      - name: Verify immutable action references
+        run: |
+          ruby .github/scripts/check-action-pins-test.rb
+          ruby .github/scripts/check-action-pins.rb .github/workflows
 
       - name: Build site
         working-directory: ./docs
@@ -54,11 +59,11 @@ jobs:
 
       - name: Configure Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
       - name: Upload Pages artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: ./docs/_site
 
@@ -76,4 +81,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install serve build check test audit clean update
+.PHONY: help install serve build check check-actions test audit clean update
 
 help:
 	@echo "Kanilrós Website"
@@ -7,6 +7,7 @@ help:
 	@echo "  make serve    Start the local server"
 	@echo "  make build    Build the production site"
 	@echo "  make check    Build, validate HTML, and audit dependencies"
+	@echo "  make check-actions  Verify immutable GitHub Action references"
 	@echo "  make update   Update locked dependencies"
 	@echo "  make clean    Remove generated files"
 
@@ -19,7 +20,11 @@ serve:
 build:
 	cd docs && JEKYLL_ENV=production bundle exec jekyll build --strict_front_matter
 
-check: build
+check-actions:
+	ruby .github/scripts/check-action-pins-test.rb
+	ruby .github/scripts/check-action-pins.rb .github/workflows
+
+check: check-actions build
 	cd docs && bundle exec ruby scripts/validate-site.rb
 	cd docs && bundle exec htmlproofer ./_site --disable-external
 	cd docs && bundle exec bundle-audit check --update


### PR DESCRIPTION
## Summary
- pin checkout, Ruby setup, Pages configuration, artifact upload, and deployment actions to commits resolved from their official release refs
- retain major-version comments so Dependabot keeps version context
- add a repository-owned YAML-aware policy that rejects tags, branches, short SHAs, expressions, and unpinned Docker images
- run policy regression coverage in CI and through `make check`

## Security validation
- all five original Codex Security PoCs now accept the pinned workflow
- policy tests cover valid SHA pins, local actions, Docker digests, tags, branches, short SHAs, expressions, flow mappings, and spaced YAML keys
- workflow YAML parse
- production Jekyll build
- metadata and structured-data validation
- HTML-Proofer internal links and anchors
- bundle-audit with updated advisory database

## Findings fixed
- `actions/checkout@v7`
- `ruby/setup-ruby@v1`
- `actions/configure-pages@v6`
- `actions/upload-pages-artifact@v5`
- `actions/deploy-pages@v5`