### PR TITLE
Add full artist name to visible site copy

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -34,7 +34,7 @@
         <div>
           <p class="site-footer__title">Kanilrós</p>
           <p>Independent music from Reykjanesbær, Iceland.</p>
-          <p class="site-footer__meta">© {{ 'now' | date: '%Y' }} Hrafnkell Brimar.</p>
+          <p class="site-footer__meta">© {{ 'now' | date: '%Y' }} Hrafnkell Brimar Hallmundsson.</p>
         </div>
         <ul class="social-links" aria-label="Kanilrós elsewhere">
           {% for social in site.data.socials %}

--- a/docs/about.markdown
+++ b/docs/about.markdown
@@ -2,14 +2,14 @@
 layout: page
 title: About
 permalink: /about/
-description: Kanilrós is the independent music project of Icelandic guitarist, songwriter, singer, and producer Hrafnkell Brimar.
+description: Kanilrós is the independent music project of Icelandic guitarist, songwriter, singer, and producer Hrafnkell Brimar Hallmundsson.
 eyebrow: The artist
 image: https://is1-ssl.mzstatic.com/image/thumb/Music221/v4/aa/34/2b/aa342be4-0577-00e8-253b-3abeb62d3d54/artwork.jpg/1000x1000bb.jpg
 ---
 
 ## The project
 
-Kanilrós is the independent music project of Hrafnkell Brimar, a guitarist, songwriter, singer, and multi-instrumentalist from Reykjanesbær, Iceland. The name means “Cinnamon Rose.” Hrafnkell writes, performs, records, mixes, and produces the music himself.
+Kanilrós is the independent music project of Hrafnkell Brimar Hallmundsson, a guitarist, songwriter, singer, and multi-instrumentalist from Reykjanesbær, Iceland. The name means “Cinnamon Rose.” Hrafnkell writes, performs, records, mixes, and produces the music himself.
 
 <dl class="artist-facts" markdown="0">
 <div>


### PR DESCRIPTION
## Summary
- add Hallmundsson to the visible About page description and biography
- add the full artist name to the site footer

## Validation
- action pin policy tests
- production Jekyll build
- metadata and structured-data validation
- HTMLProofer internal link checks
- bundle-audit